### PR TITLE
hotfix: update post url in tag page

### DIFF
--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -43,7 +43,7 @@ const title = `Tag: ${tag}`;
     {
       posts.map((post) => (
         <a
-          href={`/blog/${post.slug}`}
+          href={`/blog/${post.slug.slice(7)}`}
           class="flex items-center space-x-1 text-lg hover:text-accent gap-x-2"
         >
           <TagIcon />


### PR DESCRIPTION
- [x] updated post url in [tag] page to move correct post detail page not 404 page