### PR TITLE
fix: schema compliance, theme/giscus sync, view transition bugs

### DIFF
--- a/src/components/post/PostComments.astro
+++ b/src/components/post/PostComments.astro
@@ -21,6 +21,9 @@
   async></script>
 
 <script is:inline>
+  // @ts-nocheck — window flags via global state
+  
+  /** 현재 data-theme에 맞춰 Giscus iframe 테마 동기화 */
   function syncGiscusTheme() {
     const theme = document.documentElement.getAttribute('data-theme');
     const giscusTheme = theme === 'woong-dark' ? 'dark_tritanopia' : 'light';

--- a/src/components/post/PostComments.astro
+++ b/src/components/post/PostComments.astro
@@ -21,21 +21,29 @@
   async></script>
 
 <script is:inline>
-  // 한 번만 등록 — 페이지 전환되어도 <html data-theme> 변화 감시는 영구
-  if (!window.__giscusObserverMounted) {
-    window.__giscusObserverMounted = true;
+  function syncGiscusTheme() {
+    const theme = document.documentElement.getAttribute('data-theme');
+    const giscusTheme = theme === 'woong-dark' ? 'dark_tritanopia' : 'light';
+    const iframe = document.querySelector('iframe.giscus-frame');
+    iframe?.contentWindow?.postMessage(
+      { giscus: { setConfig: { theme: giscusTheme } } },
+      'https://giscus.app'
+    );
+  }
 
-    const observer = new MutationObserver(() => {
-      const theme = document.documentElement.getAttribute('data-theme');
-      const giscusTheme = theme === 'woong-dark' ? 'dark_tritanopia' : 'light';
-      const iframe = document.querySelector('iframe.giscus-frame');
-      iframe?.contentWindow?.postMessage(
-        { giscus: { setConfig: { theme: giscusTheme } } },
-        'https://giscus.app'
-      );
+  // 한 번만 등록 — View Transition 후에도 유지
+  if (!window.__giscusBindingsMounted) {
+    window.__giscusBindingsMounted = true;
+
+    // 1) Giscus iframe ready 신호 수신 시 초기 sync
+    //    iframe이 로드되면 giscus.app origin에서 message를 보냄
+    window.addEventListener('message', (event) => {
+      if (event.origin !== 'https://giscus.app') return;
+      if (event.data?.giscus) syncGiscusTheme();
     });
 
-    observer.observe(document.documentElement, {
+    // 2) data-theme 변경 시 sync
+    new MutationObserver(syncGiscusTheme).observe(document.documentElement, {
       attributes: true,
       attributeFilter: ['data-theme'],
     });

--- a/src/components/post/PostShareButton.astro
+++ b/src/components/post/PostShareButton.astro
@@ -22,11 +22,14 @@ const { title, url } = Astro.props;
 <script>
   import { sharePost } from '@/lib/share';
 
-  const shareButton = document.getElementById('shareButton');
-  if (shareButton) {
-    const title = shareButton.getAttribute('data-title') || '';
-    const url = shareButton.getAttribute('data-url') || '';
+  // 이벤트 위임 — DOM이 View Transition으로 교체돼도 document 리스너는 유지됨
+  document.addEventListener('click', (event) => {
+    const target = event.target as Element | null;
+    const button = target?.closest('#shareButton');
+    if (!button) return;
 
-    shareButton.addEventListener('click', () => sharePost(title, url));
-  }
+    const title = button.getAttribute('data-title') ?? '';
+    const url = button.getAttribute('data-url') ?? '';
+    sharePost(title, url);
+  });
 </script>

--- a/src/components/post/Toc.astro
+++ b/src/components/post/Toc.astro
@@ -14,6 +14,7 @@ const toc = headings.filter(
   toc.length > 0 && (
     <nav
       aria-label="목차"
+      data-pagefind-ignore
       class="collapse-arrow border-base-content/10 not-prose collapse mt-6 rounded-lg border bg-transparent"
     >
       <input type="checkbox" checked />

--- a/src/config/seo.ts
+++ b/src/config/seo.ts
@@ -49,12 +49,14 @@ export const getArticleJsonLd = ({
   },
   author: {
     '@type': 'Person',
-    name: [AUTHOR.name, AUTHOR.nameEn],
+    name: AUTHOR.name,
+    alternateName: AUTHOR.nameEn,
     url: `${siteConfig.url}/about`,
   },
   publisher: {
     '@type': 'Person',
-    name: [AUTHOR.name, AUTHOR.nameEn],
+    name: AUTHOR.name,
+    alternateName: AUTHOR.nameEn,
     url: siteConfig.url,
   },
 });

--- a/src/config/seo.ts
+++ b/src/config/seo.ts
@@ -10,6 +10,12 @@ export const getWebsiteJsonLd = () => ({
   description: siteConfig.description,
   inLanguage: siteConfig.lang,
   image: `${siteConfig.url}${siteConfig.defaultOgImage}`,
+  author: {
+    '@type': 'Person',
+    name: AUTHOR.name,
+    alternateName: AUTHOR.nameEn,
+    url: `${siteConfig.url}/about`,
+  },
 });
 
 type ArticleJsonLdParams = {

--- a/src/layouts/BaseHead.astro
+++ b/src/layouts/BaseHead.astro
@@ -64,16 +64,7 @@ const jsonLd = articleDate
 <meta name="description" content={description} />
 <meta name="generator" content={Astro.generator} />
 
-<meta
-  name="theme-color"
-  content="#121417"
-  media="(prefers-color-scheme: dark)"
-/>
-<meta
-  name="theme-color"
-  content="#eceff2"
-  media="(prefers-color-scheme: light)"
-/>
+<meta name="theme-color" content="#121417" />
 
 <!-- Open Graph -->
 <meta property="og:site_name" content={siteConfig.name} />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -20,7 +20,7 @@ const { title, description, image, articleDate, noindex } = Astro.props;
 <html lang={siteConfig.lang}>
   <head>
     <script is:inline define:vars={{ THEME }}>
-      // @ts-nocheck
+      // @ts-nocheck — THEME via define:vars, window flags via global state
       function getTheme() {
         const saved = localStorage.getItem(THEME.storageKey);
         const isLight =

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -20,17 +20,27 @@ const { title, description, image, articleDate, noindex } = Astro.props;
 <html lang={siteConfig.lang}>
   <head>
     <script is:inline define:vars={{ THEME }}>
+      // @ts-nocheck
       function getTheme() {
         const saved = localStorage.getItem(THEME.storageKey);
         const isLight =
           saved === THEME.light ||
           (!saved && matchMedia('(prefers-color-scheme: light)').matches);
-
         return isLight ? THEME.light : THEME.dark;
+      }
+
+      function syncThemeColor() {
+        const theme = document.documentElement.getAttribute('data-theme');
+        const color =
+          theme === THEME.light ? THEME.colors.light : THEME.colors.dark;
+        document
+          .querySelector('meta[name="theme-color"]')
+          ?.setAttribute('content', color);
       }
 
       function applyTheme() {
         document.documentElement.setAttribute('data-theme', getTheme());
+        syncThemeColor();
       }
 
       applyTheme();
@@ -41,6 +51,14 @@ const { title, description, image, articleDate, noindex } = Astro.props;
           getTheme()
         );
       });
+
+      if (!window.__themeColorObserverMounted) {
+        window.__themeColorObserverMounted = true;
+        new MutationObserver(syncThemeColor).observe(document.documentElement, {
+          attributes: true,
+          attributeFilter: ['data-theme'],
+        });
+      }
     </script>
     <BaseHead {title} {description} {image} {articleDate} {noindex} />
   </head>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -21,6 +21,8 @@ const { title, description, image, articleDate, noindex } = Astro.props;
   <head>
     <script is:inline define:vars={{ THEME }}>
       // @ts-nocheck — THEME via define:vars, window flags via global state
+
+      /** localStorage + 시스템 선호도로 적용할 테마 결정 */
       function getTheme() {
         const saved = localStorage.getItem(THEME.storageKey);
         const isLight =
@@ -29,6 +31,7 @@ const { title, description, image, articleDate, noindex } = Astro.props;
         return isLight ? THEME.light : THEME.dark;
       }
 
+      /** 현재 data-theme에 맞춰 browser theme-color 메타 동기화 */
       function syncThemeColor() {
         const theme = document.documentElement.getAttribute('data-theme');
         const color =
@@ -38,6 +41,7 @@ const { title, description, image, articleDate, noindex } = Astro.props;
           ?.setAttribute('content', color);
       }
 
+      /** 부트스트랩: 테마 적용 + 메타 동기화 1회 실행 */
       function applyTheme() {
         document.documentElement.setAttribute('data-theme', getTheme());
         syncThemeColor();
@@ -45,13 +49,15 @@ const { title, description, image, articleDate, noindex } = Astro.props;
 
       applyTheme();
 
+      // View Transition 시 새 문서에 미리 테마 적용 (FOUC 방지)
       document.addEventListener('astro:before-swap', (event) => {
         event.newDocument.documentElement.setAttribute(
           'data-theme',
           getTheme()
         );
       });
-
+      
+      // data-theme 변경 자동 추적 (테마 토글 + swap 후 새 문서 모두 커버)
       if (!window.__themeColorObserverMounted) {
         window.__themeColorObserverMounted = true;
         new MutationObserver(syncThemeColor).observe(document.documentElement, {

--- a/src/lib/og.ts
+++ b/src/lib/og.ts
@@ -27,12 +27,6 @@ type OgSlots = {
  * OG 이미지 외곽을 책임지는 헬퍼.
  * 모든 OG는 상단 / 중앙 / 하단의 3행 space-between 레이아웃을 공유한다.
  * 각 라우트는 세 영역의 콘텐츠만 제공한다.
- *
- * @remarks
- * satori는 JSX(ReactNode)와 plain object 입력을 모두 공식 지원하지만,
- * 타입 시그니처는 ReactNode 한쪽만 노출되어 있다.
- * 여기서는 plain object로 호출하므로 satori 호출 시 `as any` 단언이 필요하며,
- * 이는 라이브러리 한계 회피용으로 그 한 줄에서만 lint를 비활성화한다.
  */
 export async function renderOgResponse(slots: OgSlots): Promise<Response> {
   const node = {
@@ -53,6 +47,7 @@ export async function renderOgResponse(slots: OgSlots): Promise<Response> {
     },
   };
 
+  // satori는 plain object 입력을 지원하지만 타입 시그니처는 ReactNode만 노출 → as any로 우회
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const svg = await satori(node as any, {
     width: OG.width,
@@ -62,8 +57,10 @@ export async function renderOgResponse(slots: OgSlots): Promise<Response> {
     ],
   });
 
+  // satori는 SVG를 반환하지만 OG 이미지는 PNG/JPEG만 안정 지원 (Twitter/Facebook 등 SVG 미지원)
   const png = await sharp(Buffer.from(svg)).png().toBuffer();
 
+  // Buffer<ArrayBufferLike> → BodyInit 타입 호환을 위한 wrapping (Node 타입 vs DOM 타입 variance)
   return new Response(new Uint8Array(png), {
     headers: {
       'Content-Type': 'image/png',

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -6,6 +6,10 @@ export const THEME = {
   dark: 'woong-dark',
   light: 'woong-light',
   storageKey: 'theme',
+  colors: {
+    light: '#eceff2',
+    dark: '#121417',
+  },
 } as const;
 
 export type ThemeName = typeof THEME.dark | typeof THEME.light;


### PR DESCRIPTION
## Changes
- [x] JSON-LD `author.name`/`publisher.name` array → `alternateName` (schema.org compliance)
- [x] `theme-color` meta: dynamic JS sync with applied theme
- [x] Giscus: initial theme sync on iframe ready
- [x] `PostShareButton`: event delegation for View Transition compat
- [x] `getWebsiteJsonLd`: add `author` field
- [x] TOC `<nav>`: add `data-pagefind-ignore`
- [x] `og.ts`: document satori/sharp/Buffer decisions
- [x] `THEME`: add `colors` constant